### PR TITLE
Temporarily lock wazo-platform dependencies to 23.05 until portal is …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
+https://github.com/wazo-platform/wazo-lib-rest-client/archive/wazo-23.05.zip
 requests==2.21.0
 stevedore==1.29.0


### PR DESCRIPTION
…updated